### PR TITLE
Refactors the chatbot server handling

### DIFF
--- a/start_hypha_service.py
+++ b/start_hypha_service.py
@@ -164,8 +164,7 @@ class MicroscopeVideoTrack(MediaStreamTrack):
         self.frame_width = 750
         self.frame_height = 750
         logger.info(f"MicroscopeVideoTrack initialized with FPS: {self.fps}")
-        self.chatbot_server = None
-        self.server = None
+
     def draw_crosshair(self, img, center_x, center_y, size=20, color=[255, 255, 255]):
         """Draw a crosshair on the image"""
         import cv2
@@ -362,6 +361,10 @@ class Microscope:
         # Scanning control attributes
         self.scanning_in_progress = False  # Flag to prevent video buffering during scans
 
+        # Server related attributes
+        self.chatbot_server = None
+        self.server = None
+        
         # Add task status tracking
         self.task_status = {
             "move_by_distance": "not_started",


### PR DESCRIPTION
This pull request refactors the chatbot server handling in `start_hypha_service.py` to improve code clarity and reliability. The changes introduce a dedicated attribute for the chatbot server, streamline the health check process, and ensure consistent server initialization.

### Refactoring of chatbot server handling:

* **Added dedicated attributes for server management**: Introduced `self.chatbot_server` and `self.server` attributes in the class constructor to centralize server-related properties. (`[start_hypha_service.pyR364-R367](diffhunk://#diff-4df293360ee016d114b5ed554124cce6891bcb3523a40617bd028a88ea10c919R364-R367)`)
* **Simplified chatbot health check logic**: Refactored the `is_service_healthy` method to directly use `self.chatbot_server` for service retrieval and health checks, removing redundant token validation and exception handling. (`[start_hypha_service.pyL441-L456](diffhunk://#diff-4df293360ee016d114b5ed554124cce6891bcb3523a40617bd028a88ea10c919L441-L456)`)
* **Streamlined server initialization**: Updated the `setup` method to assign the connected chatbot server directly to `self.chatbot_server`, ensuring consistent usage across the class. (`[start_hypha_service.pyL2156-R2149](diffhunk://#diff-4df293360ee016d114b5ed554124cce6891bcb3523a40617bd028a88ea10c919L2156-R2149)`)